### PR TITLE
fix crash on startup with corrupted json

### DIFF
--- a/src/main/java/makamys/mclib/ext/assetdirector/AssetFetcher.java
+++ b/src/main/java/makamys/mclib/ext/assetdirector/AssetFetcher.java
@@ -146,20 +146,44 @@ public class AssetFetcher {
         
         // TODO redownload stuff if timestamp in manifest changes?
         File indexJson = new File(adDir, String.format(VERSION_INDEX_PATH, version, version));
-        if(!indexJson.exists()) {
-            downloadVersionIndex(version, indexJson);
-        }
-        VersionIndex vi = new VersionIndex(loadJson(indexJson, JsonObject.class));
+        VersionIndex vi = new VersionIndex(loadJsonOrRedownload(indexJson, JsonObject.class, f -> downloadVersionIndex(version, f)));
         versionIndexes.put(version, vi);
         
         if(!assetIndexes.containsKey(vi.assetsId)) {
             File assetIndex = new File(adDir, String.format(ASSET_INDEX_PATH, vi.assetsId));
-            if(!assetIndex.exists()) {
+            JsonObject assetIndexJson = loadJsonOrRedownload(assetIndex, JsonObject.class, f -> {
                 String url = vi.json.get("assetIndex").getAsJsonObject().get("url").getAsString();
-                copyURLToFile(url, assetIndex);
-            }
-            assetIndexes.put(vi.assetsId, new AssetIndex(loadJson(assetIndex, JsonObject.class)));
+                copyURLToFile(url, f);
+            });
+            assetIndexes.put(vi.assetsId, new AssetIndex(assetIndexJson));
         }
+    }
+    
+    /**
+     * Loads a cached JSON file, (re)downloading it if it is missing or fails to parse.
+     * A previously cached but corrupt/truncated file (e.g. from an interrupted download)
+     * is deleted and fetched again instead of being trusted indefinitely.
+     */
+    private <T> T loadJsonOrRedownload(File file, Class<T> classOfT, Downloader downloader) throws Exception {
+        Exception lastError = null;
+        for(int attempt = 0; attempt < DOWNLOAD_ATTEMPTS; attempt++) {
+            if(!file.exists()) {
+                downloader.download(file);
+            }
+            try {
+                return loadJson(file, classOfT);
+            } catch(Exception e) {
+                lastError = e;
+                LOGGER.warn("Cached file " + file + " is missing or corrupt (" + e + "); deleting and re-downloading. Attempt " + (attempt + 1) + "/" + DOWNLOAD_ATTEMPTS);
+                file.delete();
+            }
+        }
+        throw new IOException("Could not obtain a valid " + file + " after " + DOWNLOAD_ATTEMPTS + " attempts", lastError);
+    }
+    
+    @FunctionalInterface
+    private interface Downloader {
+        void download(File dest) throws Exception;
     }
     
     public void fetchJar(String version) throws IOException {
@@ -192,8 +216,12 @@ public class AssetFetcher {
     private void copyURLToFile(String source, File destination) throws IOException {
         try {
             URL url = new URL(source);
+            // Download to a temporary file and only move it into place once complete, so an
+            // interrupted download can never leave a truncated file at the real cache path.
+            File partFile = new File(destination.getPath() + ".part");
             LOGGER.trace("Downloading " + url + " to " + destination);
-            FileUtils.copyURLToFile(url, destination, DOWNLOAD_TIMEOUT, DOWNLOAD_TIMEOUT);
+            FileUtils.copyURLToFile(url, partFile, DOWNLOAD_TIMEOUT, DOWNLOAD_TIMEOUT);
+            Files.move(partFile, destination);
         } catch(IOException e) {
             LOGGER.error("Failed to download " + source + " to " + destination);
             throw e;

--- a/src/main/java/makamys/mclib/ext/assetdirector/mc/MultiVersionDefaultResourcePack.java
+++ b/src/main/java/makamys/mclib/ext/assetdirector/mc/MultiVersionDefaultResourcePack.java
@@ -109,11 +109,22 @@ public class MultiVersionDefaultResourcePack implements IResourcePack {
         scratch.namespace = fullDomain.substring(0, firstUnderscore);
         scratch.version = fullDomain.substring(firstUnderscore + 1);
         scratch.vi = fetcher.versionIndexes.get(scratch.version);
+        if(scratch.vi == null) {
+            // Version index unavailable (e.g. its asset fetch failed). Treat the resource as
+            // absent and fall back to vanilla resolution instead of crashing the client.
+            scratch.isValid = false;
+            return;
+        }
         scratch.name = convertPath(resLoc.getResourcePath(), scratch.vi.version);
         if(scratch.vi.jarContainsFile("assets/minecraft/" + scratch.name)) {
             scratch.isInJar = true;
         } else {
             scratch.isInJar = false;
+            if(fetcher.assetIndexes.get(scratch.vi.assetsId) == null) {
+                // Asset index failed to load/parse; report the resource as absent.
+                scratch.isValid = false;
+                return;
+            }
             scratch.hash = fetcher.assetIndexes.get(scratch.vi.assetsId).nameToHash
                     .get(scratch.namespace + "/" + scratch.name);
         }


### PR DESCRIPTION
Fix startup crash from corrupted/truncated AssetDirector cache
 
Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/25163
 
### Problem
 
If an asset-index download is interrupted, AssetDirector writes the truncated file straight into its cache and trusts it on every later launch. The parse failure is swallowed, the version's `AssetIndex` never makes it into the map, and a later resource reload dereferences that missing entry — crashing the client with:
 
```
java.lang.NullPointerException: Cannot read field "nameToHash" because the return value of "java.util.Map.get(Object)" is null
    at makamys.mclib.ext.assetdirector.mc.MultiVersionDefaultResourcePack.parseName(MultiVersionDefaultResourcePack.java:117)
```
 
The earlier cause is visible in the log:
 
```
[AssetDirector/ERROR] Failed to fetch assets of etfuturum
com.google.gson.JsonSyntaxException: MalformedJsonException: Unterminated string at line 1 column 277944 path $.objects.minecraft/sounds/mob/camel/step5.ogg
```
 
Because the NPE surfaces at whatever mod first reloads resources (Gendustry, SoundHandler, …), it consistently gets misattributed to unrelated mods. And it's persistent: once the bad file is cached, every relaunch crashes until the user manually deletes `assets/asset_director`.
 
### Changes
 
`AssetFetcher`:
- **Atomic downloads** — `copyURLToFile` now downloads to a `.part` file and only `Files.move`s it into place once complete, so an interrupted transfer can never leave a truncated file at the real cache path. (The existing `.part` cleanup in `init()` finally does something.)
- **Validate + retry** — new `loadJsonOrRedownload` helper parses each cached index and, if it's missing or fails to parse, deletes it and re-downloads (bounded by `DOWNLOAD_ATTEMPTS`). This self-heals caches already corrupted by the old code, so affected users don't have to wipe anything manually.
`MultiVersionDefaultResourcePack.parseName`:
- **Fail soft** — null-checks the `versionIndexes` / `assetIndexes` lookups and marks the resource invalid (falling back to vanilla resolution) instead of NPE-ing the whole client when an index is genuinely unavailable.
### Testing
 
Reproduced by truncating a cached `assets/indexes/*.json` mid-string (the exact `Unterminated string` failure). On ETFR GTNH `master` the client crashes on launch and on every relaunch; with this change AssetDirector logs the corrupt cache, re-downloads it, and the pack boots normally. Confirmed a clean cache still loads unchanged.